### PR TITLE
Fix branch index in agrees-with-branch-predicate lemma

### DIFF
--- a/lecture/lecture-notes/chapters/chapter7.tex
+++ b/lecture/lecture-notes/chapters/chapter7.tex
@@ -468,7 +468,7 @@ Note that it suffices to expand $\A$ by those new constants $c^\A$ where $c$ app
             \item If the entry $E$ is of the type `witness': If $E=\T(\exists x)\varphi(x)$, then $\A_i\models(\exists x)\varphi(x)$, so there exists $a\in A$ such that $\A_i\models\varphi(x)[e(x/a)]$. We define the branch $B_{i+1}$ as the extension of $B_i$ by the newly added entry $\T\varphi(x/c)$ and the model $\A_{i+1}$ as the expansion of $\A_i$ by the constant $c^A=a$. The case $E=\F(\forall x)\varphi(x)$ is analogous.
             \item If the entry $E$ is of the type `everyone', we define the branch $B_{i+1}$ as the extension of $B_i$ by the atomic tableau. The newly added entry is $\T\varphi(x/t)$ or $\F\varphi(x/t)$ for some $L_C$-term $t$. Suppose it is the first of these two possibilities, for the second the proof is analogous. 
             We define the model $\A_{i+1}$ as \emph{any} expansion of $\A_i$ by the new constants appearing in $t$.    
-            Since $\A_i\models(\forall x)\varphi(x)$, it also holds $\A_{i+1}\models(\forall x)\varphi(x)$ and thus $\A_{i+1}\models\varphi(x/t)$; the model $\A_{i+1}$ thus agrees with the branch $B_i$.
+            Since $\A_i\models(\forall x)\varphi(x)$, it also holds $\A_{i+1}\models(\forall x)\varphi(x)$ and thus $\A_{i+1}\models\varphi(x/t)$; the model $\A_{i+1}$ thus agrees with the branch $B_{i+1}$.
         \end{itemize}       
     \end{itemize}
 \end{proof}

--- a/lecture/skripta/kapitoly/kapitola7.tex
+++ b/lecture/skripta/kapitoly/kapitola7.tex
@@ -468,7 +468,7 @@ Všimněte si, že stačí expandovat $\A$ o nové konstanty $c^\A$ vyskytujíc�
             \item Je-li položka $P$ typu `svědek': Pokud je $P=\T(\exists x)\varphi(x)$, potom $\A_i\models(\exists x)\varphi(x)$, tedy existuje $a\in A$ takové, že $\A_i\models\varphi(x)[e(x/a)]$. Větev $V_{i+1}$ definujeme jako prodloužení $V_i$ o nově přidanou položku $\T\varphi(x/c)$ a model $\A_{i+1}$ jako expanzi $\A_i$ o konstantu $c^A=a$. Případ $P=\F(\forall x)\varphi(x)$ je obdobný.
             \item Je-li položka $P$ typu `všichni', větev $V_{i+1}$ definujeme jako prodloužení $V_i$ o atomické tablo. Nově přidaná položka je $\T\varphi(x/t)$ nebo $\F\varphi(x/t)$ pro nějaký $L_C$-term $t$. Předpokládejme, že jde o první z těchto dvou možností, pro druhou je důkaz analogický. 
             Model $\A_{i+1}$ definujeme jako \emph{libovolnou} expanzi $\A_i$ o nové konstanty vyskytující se v $t$.    
-            Protože $\A_i\models(\forall x)\varphi(x)$, platí i $\A_{i+1}\models(\forall x)\varphi(x)$ a tedy i $\A_{i+1}\models\varphi(x/t)$; model $\A_{i+1}$ se tedy shoduje s větví $V_i$.
+            Protože $\A_i\models(\forall x)\varphi(x)$, platí i $\A_{i+1}\models(\forall x)\varphi(x)$ a tedy i $\A_{i+1}\models\varphi(x/t)$; model $\A_{i+1}$ se tedy shoduje s větví $V_{i+1}$.
         \end{itemize}       
     \end{itemize}
 \end{proof}


### PR DESCRIPTION
Poslední podpoložka důkazu Lemmatu 7.4.1 (položka pro 'všichni') končí:
```tex
Protože $\A_i\models(\forall x)\varphi(x)$, platí i $\A_{i+1}\models(\forall x)\varphi(x)$ a tedy i $\A_{i+1}\models\varphi(x/t)$; model $\A_{i+1}$ se tedy shoduje s větví $V_i$.
```

Aby indukce byla správná, je třeba, aby se $A_{i+1}$ shodoval s $V_{i+1}$.

Obdobně pro anglickou verzi.
